### PR TITLE
no story/created the db connector for mysqlite and read_all endpoint

### DIFF
--- a/TodoAPP/main.py
+++ b/TodoAPP/main.py
@@ -1,7 +1,32 @@
-from fastapi import FastAPI
+from typing import Annotated
+from sqlalchemy.orm import Session
+from fastapi import FastAPI, Depends
 import models
-from database import engine
+from models import Todos
+from database import engine, SessionLocal
 
 app = FastAPI()
 
 models.Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    """
+    db dependency
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+db_dependency = Annotated[Session, Depends(get_db)]
+
+
+@app.get('/')
+async def read_all(db: db_dependency):
+    """
+    endpoint to get all Todos from the db
+    """
+    return db.query(Todos).all()


### PR DESCRIPTION
## Description
Creatd the dbb connector for mysqlite and created the read_all endpoint that
gets all items in the todo table
we are using dependency injection with db
using sessionlocal which means that we are able to contact the db
using yield instead of return and running finally after we return all the information for security messures

also created the "db_dependency" variable to use in our new endpoints.

<!-- Provide a brief description of the changes in this pull request -->

## Testing Instructions
run server, test endpoint with and check results, if you must add new info to the db before testing please do so.

sqlite3 todos.db

insert into todos (title, description, priority, complete) values ('study fastApi', 'finish DB part', 5, False);

select * from todos;

and THEN run the endpoint.

## Screenshots

![imagen](https://github.com/M0narc/fast_api/assets/46531321/dea42c95-2d11-44b1-af44-245c66ab0f2e)

<!-- If applicable, include screenshots or animated GIFs demonstrating the changes -->
